### PR TITLE
Fix for null defaults in Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,12 +118,12 @@
                     "description": "Flashing time separator character."
                 },
                 "dateTime.customFormat": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "default": null,
                     "description": "Use a custom date & time format."
                 },
                 "dateTime.fractionalPrecision": {
-                    "type": "number",
+                    "type": ["number", "null"],
                     "default": null,
                     "description": "Update interval divisor for fractional seconds.",
                     "minimum": 1,


### PR DESCRIPTION
The current default settings generate warnings in VS Code with null defaults (warning: Incorrect type, Expected string / Expected number).
This seems to be the correct format as per setting here: vscode/extensions/typescript/package.json (line 70)