### PR TITLE
Fixes Typo in README.md for Day `Do`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Custom date & time formats can be specified using the [Moment.js syntax](http://
 
 ```javascript
 // Friday, January 1st, 2016
-"dateTime.customFormat": "dddd, MMMM Mo, YYYY"
+"dateTime.customFormat": "dddd, MMMM Do, YYYY"
 
 // 2016-01-01 10:12:03
 "dateTime.customFormat": "YYYY-MM-DD HH:mm:ss"


### PR DESCRIPTION
I was wondering why copying the example in README.md was displaying "Saturday, January 1st, 2020" instead of "Saturday, January 25th, 2020". After reading the rest of README.md, I found this typo.