### PR TITLE
Locale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Displays a clock and date information in the status bar.
 |`dateTime.timeSeparatorOff`   |` `    |Flashing time separator character.             |              |
 |`dateTime.customFormat`       |`null` |Use a custom date & time format.               |              |
 |`dateTime.clipboardFormat`    |`null` |Use a custom date & time format when copying.  |              |
+|`dateTime.locale`             |`null` |Locale used for formatting.                    |              |
 |`dateTime.fractionalPrecision`|`null` |Update interval divisor for fractional seconds.|              |
 
 ### Example usage

--- a/package.json
+++ b/package.json
@@ -133,6 +133,14 @@
                     "default": null,
                     "description": "Use a custom date & time format when copying."
                 },
+                "dateTime.locale": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "Locale used for formatting."
+                },
                 "dateTime.fractionalPrecision": {
                     "type": [
                         "number",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,5 @@
 import { workspace } from "vscode";
+import * as vscode from "vscode";
 
 export enum FlashState {
     On = 1,
@@ -67,6 +68,16 @@ export function getCustomFormat(
     } else {
         const reSeparator = getFormatTimeSeparatorRegExp();
         return format.replace(reSeparator, "$1" + getTimeSeparatorOff());
+    }
+}
+
+export function getLocale(): string {
+    const locale = getConfiguration("locale");
+
+    if (!locale) {
+        return vscode.env.language;
+    } else {
+        return locale;
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,6 +56,7 @@ function getDateTimeText(
         format = configuration.getFormat(flashState);
     }
 
+    moment.locale(configuration.getLocale());
     return moment().format(format);
 }
 


### PR DESCRIPTION
New configuration string `dateTime.locale` that sets moment.js locale as in https://momentjs.com/docs/#/i18n/changing-locale/
If `null`, uses [vscode display language](https://code.visualstudio.com/docs/getstarted/locales) from [`vscode.env.language`](https://code.visualstudio.com/api/references/vscode-api#env)
Solves https://github.com/rid9/DateTime/issues/3 (I guess)